### PR TITLE
Add capabilities to driftscan

### DIFF
--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -68,21 +68,6 @@ def svd_gen(A, errmsg=None, *args, **kwargs):
 
     return res
 
-def add_reg(A):
-    try:
-        res = la.svd(A)
-    except la.LinAlgError:
-        sv = la.svdvals(A)[0]
-        At = A + sv * 1e-10 * np.eye(A.shape[0], A.shape[1])
-        try:
-            res = la.svd(At)
-        except la.LinAlgError as e:
-            print "Failed completely"
-            raise e
-
-        return At
-    return A
-
 
 def matrix_image(A, rtol=1e-8, atol=None, errmsg=""):
 

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -24,7 +24,6 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 import pickle
 import os
 import time
-import logging
 
 import numpy as np
 import scipy.linalg as la
@@ -248,8 +247,6 @@ class BeamTransfer(object):
         self.directory = directory
         self.telescope = telescope
 
-        logging.basicConfig(level=logging.DEBUG, filename='svdfail.log')
-        self.logger = logging.getLogger('beam_transfer')
         # Create directory if required
         if mpiutil.rank0 and not os.path.exists(directory):
             os.makedirs(directory)
@@ -1444,8 +1441,6 @@ class BeamTransfer(object):
             SVD vector to return.
         """
         npol = 1 if temponly else self.telescope.num_pol_sky
-        print("temponly", temponly)
-        print("npol", npol)
 
         # if not conj:
         #     raise Exception("Not implemented non conj yet.")

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -552,7 +552,7 @@ class BeamTransfer(object):
 
     # ====== Generation of all the cache files ==========
 
-    def generate(self, regen=False, skip_svd=False):
+    def generate(self, regen=False, skip_svd=False, skip_svd_inv=False):
         """Save out all beam transfer matrices to disk.
 
         Parameters
@@ -576,7 +576,7 @@ class BeamTransfer(object):
         self._generate_mfiles(regen)
 
         if not skip_svd:
-            self._generate_svdfiles(regen)
+            self._generate_svdfiles(regen, skip_svd_inv)
 
         # If we're part of an MPI run, synchronise here.
         mpiutil.barrier()
@@ -843,7 +843,8 @@ class BeamTransfer(object):
             # Print out timing
             print("=== MPI transpose took %f s ===" % (et - st))
 
-    def _generate_svdfiles(self, regen=False):
+    def _generate_svdfiles(self, regen=False, skip_svd_inv=False):
+
         ## Generate all the SVD transfer matrices by simply iterating over all
         ## m, performing the SVD, combining the beams and then write out the
         ## results.
@@ -888,26 +889,27 @@ class BeamTransfer(object):
                 dtype=np.complex128,
             )
 
-            # Create a chunked dataset for writing the inverse SVD beam matrix into.
-            dsize_ibsvd = (
-                self.telescope.nfreq,
-                self.telescope.num_pol_sky,
-                self.telescope.lmax + 1,
-                self.svd_len,
-            )
-            csize_ibsvd = (
-                1,
-                self.telescope.num_pol_sky,
-                self.telescope.lmax + 1,
-                min(10, self.svd_len),
-            )
-            dset_ibsvd = fs.create_dataset(
-                "invbeam_svd",
-                dsize_ibsvd,
-                chunks=csize_ibsvd,
-                compression="lzf",
-                dtype=np.complex128,
-            )
+            if not skip_svd_inv:
+                # Create a chunked dataset for writing the inverse SVD beam matrix into.
+                dsize_ibsvd = (
+                    self.telescope.nfreq,
+                    self.telescope.num_pol_sky,
+                    self.telescope.lmax + 1,
+                    self.svd_len,
+                )
+                csize_ibsvd = (
+                    1,
+                    self.telescope.num_pol_sky,
+                    self.telescope.lmax + 1,
+                    min(10, self.svd_len),
+                )
+                dset_ibsvd = fs.create_dataset(
+                    "invbeam_svd",
+                    dsize_ibsvd,
+                    chunks=csize_ibsvd,
+                    compression="lzf",
+                    dtype=np.complex128,
+                )
 
             # Create a chunked dataset for the stokes T U-matrix (left evecs)
             dsize_ut = (self.telescope.nfreq, self.svd_len, self.ntel)
@@ -999,21 +1001,6 @@ class BeamTransfer(object):
                     ut = ut3
                     sig = s3[:nmodes]
                     beam = np.dot(ut3, bfr)
-                    try:
-                        ibeam = la.pinv(beam)
-                    except la.LinAlgError as e:
-                        print "m=%i f=%i" % (mi, fi)
-                        beamfail = h5py.File('beamfail.h5', 'w')
-                        beamfail.create_dataset('beam', beamfail, compression='lzf', dtype=np.complex128)
-                        beamfail.close()
-                        self.logger.warning("Not able to pseudo invert m={0} f={1} adding regularisation".format(mi, fi))
-                        beam_reg = add_reg(beam)
-                        try:
-                            ibeam = la.pinv(beam_reg)
-                        except la.LinAlgError as e:
-                            print "Regularisation did not work for m=%i f=%i" % (mi, fi)
-                            self.logger.warning("Regularisation did not work.")
-                            raise e
 
                     # Save out the evecs (for transforming from the telescope frame into the SVD basis)
                     dset_ut[fi, :nmodes] = ut * noisew[np.newaxis, :]
@@ -1023,10 +1010,12 @@ class BeamTransfer(object):
                         nmodes, self.telescope.num_pol_sky, self.telescope.lmax + 1
                     )
 
-                    # Find the pseudo-inverse of the beam matrix and save to disk.
-                    dset_ibsvd[fi, :, :, :nmodes] = ibeam.reshape(
-                        self.telescope.num_pol_sky, self.telescope.lmax + 1, nmodes
-                    )
+                    if not skip_svd_inv:
+                        ibeam = la.pinv(beam)
+                        # Find the pseudo-inverse of the beam matrix and save to disk.
+                        dset_ibsvd[fi, :, :, :nmodes] = ibeam.reshape(
+                            self.telescope.num_pol_sky, self.telescope.lmax + 1, nmodes
+                        )
 
                     # Save out the singular values for each block
                     dset_sig[fi, :nmodes] = sig
@@ -1470,6 +1459,8 @@ class BeamTransfer(object):
             SVD vector to return.
         """
         npol = 1 if temponly else self.telescope.num_pol_sky
+        print("temponly", temponly)
+        print("npol", npol)
 
         # if not conj:
         #     raise Exception("Not implemented non conj yet.")

--- a/drift/core/manager.py
+++ b/drift/core/manager.py
@@ -91,6 +91,7 @@ class ProductManager(object):
     gen_proj = False
 
     skip_svd = False
+    skip_svd_inv = False
 
     @classmethod
     def from_config(cls, configfile):
@@ -221,7 +222,11 @@ class ProductManager(object):
         if "skip_svd" in yconf["config"] and yconf["config"]["skip_svd"]:
             self.skip_svd = True
 
-        self.kltransforms = {}
+        if 'skip_svd_inv' in yconf['config'] and yconf['config']['skip_svd_inv']:
+            self.skip_svd_inv = True
+
+        self.kltransforms  = {}
+
 
         if "kltransform" in yconf:
 
@@ -268,7 +273,7 @@ class ProductManager(object):
     def generate(self):
 
         if self.gen_beams:
-            self.beamtransfer.generate(skip_svd=self.skip_svd)
+            self.beamtransfer.generate(skip_svd=self.skip_svd, skip_svd_inv=self.skip_svd_inv)
 
         if self.gen_kl:
 

--- a/drift/core/manager.py
+++ b/drift/core/manager.py
@@ -222,11 +222,10 @@ class ProductManager(object):
         if "skip_svd" in yconf["config"] and yconf["config"]["skip_svd"]:
             self.skip_svd = True
 
-        if 'skip_svd_inv' in yconf['config'] and yconf['config']['skip_svd_inv']:
+        if "skip_svd_inv" in yconf["config"] and yconf["config"]["skip_svd_inv"]:
             self.skip_svd_inv = True
 
-        self.kltransforms  = {}
-
+        self.kltransforms = {}
 
         if "kltransform" in yconf:
 
@@ -273,7 +272,9 @@ class ProductManager(object):
     def generate(self):
 
         if self.gen_beams:
-            self.beamtransfer.generate(skip_svd=self.skip_svd, skip_svd_inv=self.skip_svd_inv)
+            self.beamtransfer.generate(
+                skip_svd=self.skip_svd, skip_svd_inv=self.skip_svd_inv
+            )
 
         if self.gen_kl:
 

--- a/drift/core/psestimation.py
+++ b/drift/core/psestimation.py
@@ -509,8 +509,12 @@ class PSEstimation(with_metaclass(abc.ABCMeta, config.Reader)):
         fisher_loc, bias_loc = zip(*fisher_bias_list)
 
         # Sum over all local m-modes to get the over all Fisher and bias pe process
-        fisher_loc = np.sum(np.array(fisher_loc), axis=0).real # Be careful of the .real here
-        bias_loc = np.sum(np.array(bias_loc), axis=0).real # Be careful of the .real here
+        fisher_loc = np.sum(
+            np.array(fisher_loc), axis=0
+        ).real  # Be careful of the .real here
+        bias_loc = np.sum(
+            np.array(bias_loc), axis=0
+        ).real  # Be careful of the .real here
 
         self.fisher = mpiutil.allreduce(fisher_loc, op=MPI.SUM)
         self.bias = mpiutil.allreduce(bias_loc, op=MPI.SUM)

--- a/drift/core/telescope.py
+++ b/drift/core/telescope.py
@@ -336,7 +336,9 @@ class TransitTelescope(with_metaclass(abc.ABCMeta, config.Reader, ctime.Observer
 
             # Bin the channels together
             if len(basefreq) % self.channel_bin != 0:
-                raise Exception("Channel binning must exactly divide the total number of channels")
+                raise Exception(
+                    "Channel binning must exactly divide the total number of channels"
+                )
 
             basefreq = basefreq.reshape(-1, self.channel_bin).mean(axis=-1)
 
@@ -346,8 +348,10 @@ class TransitTelescope(with_metaclass(abc.ABCMeta, config.Reader, ctime.Observer
             self._frequencies = basefreq
 
         else:
-            #self._frequencies = np.linspace(self.freq_lower, self.freq_upper, self.num_freq)
-            self._frequencies = self.freq_lower + (np.arange(self.num_freq) + 0.5) * ((self.freq_upper - self.freq_lower) / self.num_freq)
+            # self._frequencies = np.linspace(self.freq_lower, self.freq_upper, self.num_freq)
+            self._frequencies = self.freq_lower + (np.arange(self.num_freq) + 0.5) * (
+                (self.freq_upper - self.freq_lower) / self.num_freq
+            )
 
     @property
     def wavelengths(self):


### PR DESCRIPTION
Summary:

- changes to `manager.py` and `beamtransfer.py`:  allow skipping the inversion of svd beams 
- changes to `psestimation.py`: summation over local m fisher matrices and followed by allreduce.
- changes to `telescope.py`: allow frequency binning like in CHIME