### PR TITLE
chore(tests): move cached data from LFS to chime webserver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-*.tar.gz filter=lfs diff=lfs merge=lfs -text
 drift/_version.py export-subst

--- a/tests/drift_testproducts.tar.gz
+++ b/tests/drift_testproducts.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eb2fd34a7be7d91f4378eace7182452d0695579f1a5f96bef507eb2d44eeafb
-size 12520179

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -4,6 +4,7 @@ generation."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from future.moves.urllib.request import urlretrieve
 
 # === End Python 2/3 compatibility
 
@@ -16,7 +17,6 @@ import sys
 import numpy as np
 import pytest
 import h5py
-
 
 # Ensure we're using the correct package
 _basedir = os.path.realpath(os.path.dirname(__file__))
@@ -97,7 +97,14 @@ def manager(products_run):
 def saved_products(tmpdir_factory):
 
     _base = str(tmpdir_factory.mktemp("saved_products"))
+
     prodfile = os.path.join(_basedir, "drift_testproducts.tar.gz")
+
+    # Download the test products if they don't exist locally
+    if not os.path.exists(prodfile):
+        print("Downloading test verification data.")
+        url = "http://bao.chimenet.ca/testcache/drift_testproducts.tar.gz"
+        urlretrieve(url, prodfile)
 
     with tarfile.open(prodfile, "r:gz") as tf:
         tf.extractall(path=_base)


### PR DESCRIPTION
This should hopefully stop things failing because we've hit github's LFS
bandwith quota.