### PR TITLE
Repairs to BeamTransferNoSVD

### DIFF
--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1738,6 +1738,9 @@ class BeamTransferNoSVD(BeamTransfer):
 
     noise_weight = False
 
+    def _generate_svdfiles(self, regen=False, skip_svd_inv=False):
+        print("======== Skipping telescope SVD step ========")
+
     def project_matrix_sky_to_svd(self, mi, mat, temponly=False):
         """Project a covariance matrix from the sky into the SVD basis.
 
@@ -1773,9 +1776,9 @@ class BeamTransferNoSVD(BeamTransfer):
         Returns
         -------
         tvec : np.ndarray
-            Telescope vector to return, packed as [nfreq, ntel].
+            Telescope vector to return, packed as [ndof].
         """
-        return self.project_vector_sky_to_telescope(mi, vec)
+        return self.project_vector_sky_to_telescope(mi, vec).flatten()
 
     def project_matrix_diagonal_telescope_to_svd(self, mi, dmat, *args, **kwargs):
         """Project a diagonal matrix from the telescope basis to the SVD basis.
@@ -1807,9 +1810,9 @@ class BeamTransferNoSVD(BeamTransfer):
         Returns
         -------
         tvec : np.ndarray
-            SVD vector to return, packed as [nfreq, ntel].
+            SVD vector to return, packed as [ndof].
         """
-        return vec
+        return vec.flatten()
 
     def project_vector_svd_to_sky(self, mi, vec, temponly=False, conj=False):
         """Project a vector from the the SVD basis into the sky basis.

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1020,12 +1020,12 @@ class BeamTransfer(config.Reader):
         mi : integer
             Mode index to fetch for.
         vec : np.ndarray
-            Sky data vector packed as [freq, baseline, polarisation]
+            Telescope data vector, packed as [nfreq, ntel].
 
         Returns
         -------
         tvec : np.ndarray
-            Sky vector to return.
+            Sky vector to return, packed as [nfreq, npol, lmax+1].
         """
 
         vecb = np.zeros((self.nfreq, self.nsky), dtype=np.complex128)
@@ -1084,7 +1084,7 @@ class BeamTransfer(config.Reader):
         Returns
         -------
         tmat : np.ndarray
-            Covariance in telescope basis.
+            Covariance in telescope basis, packed as [nfreq, ntel, nfreq, ntel].
         """
         npol = self.telescope.num_pol_sky
         lside = self.telescope.lmax + 1
@@ -1193,7 +1193,7 @@ class BeamTransfer(config.Reader):
         ----------
         mi : integer
             Mode index to fetch for.
-        mat : np.ndarray
+        dmat : np.ndarray
             Sky matrix packed as [nfreq, ntel]
 
         Returns
@@ -1733,17 +1733,74 @@ class BeamTransferNoSVD(BeamTransfer):
     svcut = 0.0
 
     def project_matrix_sky_to_svd(self, mi, mat, *args, **kwargs):
+        """Project a covariance matrix from the sky into the SVD basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+        mat : np.ndarray
+            Sky matrix packed as [pol, pol, l, freq, freq].
+
+        Returns
+        -------
+        tmat : np.ndarray
+            SVD-basis matrix, packed as [ndof, ndof]. Recall that
+            ndof = ntel * nfreq = 2 * nbase * nfreq.
+        """
         return self.project_matrix_sky_to_telescope(mi, mat).reshape(
             self.ndof(mi), self.ndof(mi)
         )
 
     def project_vector_sky_to_svd(self, mi, vec, *args, **kwargs):
+        """Project a vector from the sky into the SVD basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+        vec : np.ndarray
+            Sky data vector packed as [nfreq, npol, lmax+1]
+
+        Returns
+        -------
+        tvec : np.ndarray
+            Telescope vector to return, packed as [nfreq, ntel].
+        """
         return self.project_vector_sky_to_telescope(mi, vec)
 
     def project_matrix_diagonal_telescope_to_svd(self, mi, dmat, *args, **kwargs):
+        """Project a diagonal matrix from the telescope basis to the SVD basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+        dmat : np.ndarray
+            Diagonal telescope-basis matrix packed as [nfreq, ntel].
+
+        Returns
+        -------
+        tvec : np.ndarray
+            SVD-basis matrix to return, packed as [ndof, ndof].
+        """
         return np.diag(dmat.flatten())
 
     def project_vector_telescope_to_svd(self, mi, vec, *args, **kwargs):
+        """Project a vector from the telescope basis into the SVD basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+        vec : np.ndarray
+            Telescope data vector packed as [nfreq, ntel].
+
+        Returns
+        -------
+        tvec : np.ndarray
+            SVD vector to return, packed as [nfreq, ntel].
+        """
         return vec
 
     def project_vector_svd_to_sky(self, mi, vec, temponly=False, conj=False):
@@ -1794,13 +1851,50 @@ class BeamTransferNoSVD(BeamTransfer):
         return svec
 
     def beam_svd(self, mi, *args, **kwargs):
+        """Fetch beam SVD matrix.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+
+        Returns
+        -------
+        mat : np.ndarray
+            Beam-SVD matrix, which in this class is just the beam transfer
+            matrix, packed as [nfreq, 2, nbase, npol, lmax+1].
+        """
         return self.beam_m(mi)
 
     def ndof(self, mi, *args, **kwargs):
+        """Compute number of degrees of freedom in telescope basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+
+        Returns
+        -------
+        n : int
+            N_dof = ntel * nfreq = nbase * 2 * nfreq.
+        """
         return self.ntel * self.nfreq
 
     @property
     def ndofmax(self):
+        """Compute number of degrees of freedom in telescope basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+
+        Returns
+        -------
+        n : int
+            N_dof = ntel * nfreq = nbase * 2 * nfreq.
+        """
         return self.ntel * self.nfreq
 
 

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1738,6 +1738,30 @@ class BeamTransferNoSVD(BeamTransfer):
 
     noise_weight = False
 
+    def _svd_num(self, mi):
+        """Compute number of SVD modes meeting the cut.
+        
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+
+        Returns
+        -------
+        svnum : np.ndarray
+            Number of remaining SV modes at each frequency.
+        svbounds : np.ndarray
+            Indices bounding SV modes after concatenation over frequency.
+            Has size nfreq+1.
+        """
+        # Number of significant sv modes at each frequency
+        svnum = (np.ones(self.nfreq) * self.ntel).astype(int)
+
+        # Calculate the block bounds within the full matrix
+        svbounds = np.cumsum(np.insert(svnum, 0, 0))
+
+        return svnum, svbounds
+
     def _generate_svdfiles(self, regen=False, skip_svd_inv=False):
         print("======== Skipping telescope SVD step ========")
 

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1780,6 +1780,23 @@ class BeamTransferNoSVD(BeamTransfer):
         """
         return self.project_vector_sky_to_telescope(mi, vec).flatten()
 
+    def project_matrix_telescope_to_svd(self, mi, mat):
+        """Map a matrix from the telescope space into the SVD basis.
+
+        Parameters
+        ----------
+        mi : integer
+            Mode index to fetch for.
+        mat : np.ndarray
+            Telescope-basis matrix, packed as [freq, baseline, freq, baseline].
+
+        Returns
+        -------
+        out_mat : np.ndarray
+            SVD-basis matrix, packed as [ndof, ndof].
+        """
+        return mat.reshape(self.ndof(mi), self.ndof(mi))
+
     def project_matrix_diagonal_telescope_to_svd(self, mi, dmat, *args, **kwargs):
         """Project a diagonal matrix from the telescope basis to the SVD basis.
 

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1734,6 +1734,14 @@ class BeamTransferFullSVD(BeamTransfer):
 
 
 class BeamTransferNoSVD(BeamTransfer):
+    """Subclass of BeamTransfer that skips SVD decomposition.
+
+    To use in a driftscan config file, the `nosvd` flag needs
+    to be set. (In this case, the value of `skip_svd` is ignored,
+    because the SVD step is automatically skipped.)
+    """
+    
+    # No SV cut
     svcut = 0.0
 
     noise_weight = False
@@ -1754,7 +1762,9 @@ class BeamTransferNoSVD(BeamTransfer):
             Indices bounding SV modes after concatenation over frequency.
             Has size nfreq+1.
         """
-        # Number of significant sv modes at each frequency
+        # Number of significant SV modes at each frequency,
+        # which is *all* SV modes in no-SVD case, since SV modes
+        # are just the m-modes.
         svnum = (np.ones(self.nfreq) * self.ntel).astype(int)
 
         # Calculate the block bounds within the full matrix

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -1740,7 +1740,7 @@ class BeamTransferNoSVD(BeamTransfer):
     to be set. (In this case, the value of `skip_svd` is ignored,
     because the SVD step is automatically skipped.)
     """
-    
+
     # No SV cut
     svcut = 0.0
 
@@ -1748,7 +1748,7 @@ class BeamTransferNoSVD(BeamTransfer):
 
     def _svd_num(self, mi):
         """Compute number of SVD modes meeting the cut.
-        
+
         Parameters
         ----------
         mi : integer
@@ -1882,7 +1882,9 @@ class BeamTransferNoSVD(BeamTransfer):
         """
 
         if temponly:
-            raise NotImplementedError("temponly not implemented for no-SVD project_vector_svd_to_sky!")
+            raise NotImplementedError(
+                "temponly not implemented for no-SVD project_vector_svd_to_sky!"
+            )
 
         # Create the output matrix
         svec = np.zeros(
@@ -1897,8 +1899,11 @@ class BeamTransferNoSVD(BeamTransfer):
 
             # Loop through frequencies, doing tel-to-sky projection at each freq
             for fi in range(self.nfreq):
-                svec[fi] = np.dot(beam[fi].T.conj(), vec.reshape(self.nfreq, self.ntel, -1)[fi]).reshape(
-                    (self.telescope.num_pol_sky, self.telescope.lmax + 1) + vec.shape[1:]
+                svec[fi] = np.dot(
+                    beam[fi].T.conj(), vec.reshape(self.nfreq, self.ntel, -1)[fi]
+                ).reshape(
+                    (self.telescope.num_pol_sky, self.telescope.lmax + 1)
+                    + vec.shape[1:]
                 )
 
         else:
@@ -1906,8 +1911,11 @@ class BeamTransferNoSVD(BeamTransfer):
 
             # Loop through frequencies, doing tel-to-sky projection at each freq
             for fi in range(self.nfreq):
-                svec[fi] = np.dot(ibeam[fi], vec.reshape(self.nfreq, self.ntel, -1)[fi]).reshape(
-                    (self.telescope.num_pol_sky, self.telescope.lmax + 1) + vec.shape[1:]
+                svec[fi] = np.dot(
+                    ibeam[fi], vec.reshape(self.nfreq, self.ntel, -1)[fi]
+                ).reshape(
+                    (self.telescope.num_pol_sky, self.telescope.lmax + 1)
+                    + vec.shape[1:]
                 )
 
         return svec

--- a/drift/core/psestimation.py
+++ b/drift/core/psestimation.py
@@ -637,7 +637,7 @@ class PSEstimation(config.Reader, metaclass=abc.ABCMeta):
                     lyvec.conj()
                     * np.dot(self.clarray[bi][li].astype(np.complex128), lxvec),
                     axis=0,
-                ).astype(
+                ).real.astype(
                     np.float64
                 )  # TT only.
 


### PR DESCRIPTION
A few things are broken in the master version of `BeamTransferNoSVD`, and this PR fixes them all. As a bonus, I've fixed an annoying complex-to-real casting warning that happens during power spectrum estimation.