### PR TITLE
Propagate skip_svd_inv parameter in ProductManager

### DIFF
--- a/drift/core/manager.py
+++ b/drift/core/manager.py
@@ -234,6 +234,9 @@ class ProductManager(object):
         if yconf["config"].get("skip_svd"):
             self.skip_svd = True
 
+        if yconf["config"].get("skip_svd_inv"):
+            self.skip_svd_inv = True
+
         ## Configure the KL Transforms
         self.kltransforms = {}
 

--- a/drift/core/manager.py
+++ b/drift/core/manager.py
@@ -290,7 +290,7 @@ class ProductManager(object):
 
         # Generate the transfer matrices
         if self.gen_beams:
-            self.beamtransfer.generate(skip_svd=self.skip_svd)
+            self.beamtransfer.generate(skip_svd=self.skip_svd, skip_svd_inv=self.skip_svd_inv)
 
         # Generate the KLs
         if self.gen_kl:


### PR DESCRIPTION
Currently the `skip_inv_svd` parameter isn't passed to `beamtransfer.generate` in `ProductManager`. I sometimes force this to be used as we don't really use the inverse svds and producing them occasionally causes linear algebra related failures. Fixing this makes it easier to do that with the config file.