### PR TITLE
Fix CI errors introduced in d80c61a

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,9 @@ jobs:
 
     - name: Install apt dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -76,6 +78,7 @@ jobs:
 
     - name: Install apt dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin
 
     - name: Install pip dependencies

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install apt dependencies
         run: |

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin
       - uses: actions/checkout@v2
       - name: Install pip requirements

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx >= 4.0, < 5.0
+Sphinx
 sphinx_rtd_theme

--- a/drift/core/beamtransfer.py
+++ b/drift/core/beamtransfer.py
@@ -904,9 +904,9 @@ class BeamTransfer(config.Reader):
                                         fs.attrs["inv_bsvd_from_pinv2"] = [fi]
                                     else:
                                         bad_freqs = fs.attrs["inv_bsvd_from_pinv2"]
-                                        fs.attrs[
-                                            "inv_bsvd_from_pinv2"
-                                        ] = bad_freqs.append(fi)
+                                        fs.attrs["inv_bsvd_from_pinv2"] = (
+                                            bad_freqs.append(fi)
+                                        )
                                 except:
                                     # If pinv2 fails, print error message
                                     raise Exception(
@@ -1218,9 +1218,9 @@ class BeamTransfer(config.Reader):
             fbeam = beam[fi, : svnum[fi], :]  # Beam matrix for this frequency and cut
             lmat = dmat[fi, :]  # Matrix section for this frequency
 
-            matf[
-                svbounds[fi] : svbounds[fi + 1], svbounds[fi] : svbounds[fi + 1]
-            ] = np.dot((fbeam * lmat), fbeam.T.conj())
+            matf[svbounds[fi] : svbounds[fi + 1], svbounds[fi] : svbounds[fi + 1]] = (
+                np.dot((fbeam * lmat), fbeam.T.conj())
+            )
 
         svdfile.close()
 


### PR DESCRIPTION
I merged a stale PR (https://github.com/radiocosmology/driftscan/pull/115) and unwittingly introduced some CI errors into master (apologies!), related to black, the apt cache, and Sphinx. (Several of the same errors were fixed in draco in https://github.com/radiocosmology/draco/pull/261.) This PR fixes all of those.