### PR TITLE
Remove openmpi bind command when generating test data

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -68,8 +68,8 @@ def _gen_prod(output_dir: Path, config: Path):
         # On macOS this has recently been giving problems when running the MPI
         # job from within pytest
         if "DRIFT_NO_MPI" not in os.environ:
-            nproc = 2  # Use a fixed number to check that the MPI code works
-            cmd = ("mpirun -np %i --oversubscribe -bind-to none " % nproc) + cmd
+            # Use a fixed number to check that the MPI code works
+            cmd = "mpirun -n 2 --oversubscribe " + cmd
 
         print(f"Running test in: {output_dir}")
         print("Generating products:", cmd)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -62,14 +62,7 @@ def _gen_prod(output_dir: Path, config: Path):
 
         shutil.copy(config, output_dir / "params.yaml")
 
-        cmd = "drift-makeproducts run params.yaml"
-
-        # If we're not on macOS try running under MPI
-        # On macOS this has recently been giving problems when running the MPI
-        # job from within pytest
-        if "DRIFT_NO_MPI" not in os.environ:
-            # Use a fixed number to check that the MPI code works
-            cmd = "mpirun -n 2 --oversubscribe " + cmd
+        cmd = "mpirun -np 2 --oversubscribe drift-makeproducts run params.yaml"
 
         print(f"Running test in: {output_dir}")
         print("Generating products:", cmd)


### PR DESCRIPTION
Based on the history here, this test was already problematic on `macos`, but at some point we removed the `DRIFT_NO_MPI` environment variable entirely. OpenMPI doesn't directly support core binding on macos, so the test output was never being written.

I'm a bit surprised that `-bind-to none` wasn't working, but my guess is that there was a version bump which made that start to explicitly fail.